### PR TITLE
Update 0.2.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: 5d20a3b9aa851ca56dd09c57bb6d790cbe331e3e4d4c86e8a16575c9400071b6
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   number: 0
+  skip: True  # [py<38]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - hatchling
     - pip
   run:
-    - python >=3.7
+    - python
     - requests
     - tqdm
     - packaging
@@ -35,9 +35,13 @@ test:
 
 about:
   home: https://github.com/Kaggle/kagglehub
+  description: |
+    KaggleHub is a Python package that provides a simple API to access Kaggle resources anywhere.
   summary: Access Kaggle resources anywhere
   license: Apache-2.0
   license_file: LICENSE
+  dev_url: https://github.com/Kaggle/kagglehub
+  doc_url: https://www.kaggle.com/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,9 @@ about:
   summary: Access Kaggle resources anywhere
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
   dev_url: https://github.com/Kaggle/kagglehub
-  doc_url: https://www.kaggle.com/docs
+  doc_url: https://github.com/Kaggle/kagglehub/blob/main/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## ☆kagglehub 0.2.7 Update ☆
Initial push of kagglehub-feedstock to defaults.
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5261)
[Upstream](https://github.com/Kaggle/kagglehub)
# Changes
- Updated version number and `sha256`
- Added recent dependencies for `testing` and `host`.
-  Added additional information to `about` section